### PR TITLE
Feature/Realize the Laravel full site access PV statistics middleware function based on Redis

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\SiteVisits::class,
     ];
 
     /**

--- a/app/Http/Middleware/SiteVisits.php
+++ b/app/Http/Middleware/SiteVisits.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redis;
+
+class SiteVisits
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        Redis::incr('site_total_visits');
+        return $next($request);
+    }
+}

--- a/pressure-test/README.md
+++ b/pressure-test/README.md
@@ -1,0 +1,23 @@
+<p align="center">
+    <a href="https://blog.csdn.net/william_n/article/details/89956463" target="_blank">
+        <img src="https://img-blog.csdnimg.cn/img_convert/4a0565a886238b8dfe12a80566417ec2.png">
+    </a>
+</p>
+
+## 并发/压力测试
+
+### 环境
+- Docker 2GB 6CPUs in Mac
+
+### 工具
+- ab [ApacheBench]
+
+### 命令
+- ab -n 100 -c 10 http://localhost/site_visits [终端输出]
+- ab -n 100 -c 10 -w http://localhost/site_visits >> site_visits.html [生成html]
+
+### 列表
+- 全局访问计数器 [http://localhost/site_visits]
+
+### 结果
+- pressure-test/site_visits.html

--- a/pressure-test/site_visits.html
+++ b/pressure-test/site_visits.html
@@ -1,0 +1,29 @@
+<p>
+ This is ApacheBench, Version 2.3 <i>&lt;$Revision: 1843412 $&gt;</i><br>
+ Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/<br>
+ Licensed to The Apache Software Foundation, http://www.apache.org/<br>
+</p>
+<p>
+..done
+
+
+<table >
+<tr ><th colspan=2 bgcolor=white>Server Software:</th><td colspan=2 bgcolor=white></td></tr>
+<tr ><th colspan=2 bgcolor=white>Server Hostname:</th><td colspan=2 bgcolor=white>localhost</td></tr>
+<tr ><th colspan=2 bgcolor=white>Server Port:</th><td colspan=2 bgcolor=white>80</td></tr>
+<tr ><th colspan=2 bgcolor=white>Document Path:</th><td colspan=2 bgcolor=white>/site_visits</td></tr>
+<tr ><th colspan=2 bgcolor=white>Document Length:</th><td colspan=2 bgcolor=white>27 bytes</td></tr>
+<tr ><th colspan=2 bgcolor=white>Concurrency Level:</th><td colspan=2 bgcolor=white>10</td></tr>
+<tr ><th colspan=2 bgcolor=white>Time taken for tests:</th><td colspan=2 bgcolor=white>2.777 seconds</td></tr>
+<tr ><th colspan=2 bgcolor=white>Complete requests:</th><td colspan=2 bgcolor=white>100</td></tr>
+<tr ><th colspan=2 bgcolor=white>Failed requests:</th><td colspan=2 bgcolor=white>0</td></tr>
+<tr ><th colspan=2 bgcolor=white>Total transferred:</th><td colspan=2 bgcolor=white>116800 bytes</td></tr>
+<tr ><th colspan=2 bgcolor=white>HTML transferred:</th><td colspan=2 bgcolor=white>2700 bytes</td></tr>
+<tr ><th colspan=2 bgcolor=white>Requests per second:</th><td colspan=2 bgcolor=white>36.01</td></tr>
+<tr ><th colspan=2 bgcolor=white>Transfer rate:</th><td colspan=2 bgcolor=white>41.08 kb/s received</td></tr>
+<tr ><th bgcolor=white colspan=4>Connnection Times (ms)</th></tr>
+<tr ><th bgcolor=white>&nbsp;</th> <th bgcolor=white>min</th>   <th bgcolor=white>avg</th>   <th bgcolor=white>max</th></tr>
+<tr ><th bgcolor=white>Connect:</th><td bgcolor=white>    0</td><td bgcolor=white>    0</td><td bgcolor=white>    1</td></tr>
+<tr ><th bgcolor=white>Processing:</th><td bgcolor=white>   30</td><td bgcolor=white>  261</td><td bgcolor=white>  351</td></tr>
+<tr ><th bgcolor=white>Total:</th><td bgcolor=white>   30</td><td bgcolor=white>  261</td><td bgcolor=white>  352</td></tr>
+</table>

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,3 +16,17 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+// Test connector of Redis
+Route::get('/connection', function () {
+    dd(\Illuminate\Support\Facades\Redis::connection());
+    // 或者
+    dd(app('redis')->connection());
+    // 或者
+    dd(app('redis.connection'));
+});
+
+// Acquire total visits of site
+Route::get('/site_visits', function () {
+    return '网站全局访问量：' . \Illuminate\Support\Facades\Redis::get('site_total_visits');
+});


### PR DESCRIPTION
## Desc
*  基于 Redis 实现 Laravel 全站访问 PV 统计中间件功能
*  同时添加压力测试及测试结果

## Learning link
https://laravelacademy.org/post/22165

## This PR contains (select one)
- [x] New Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Test
- [ ] Chore (Other changes that don’t modify src or test files)
- [ ] Other (Please, specify)


